### PR TITLE
Update to version 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ test_run_dir/
 build/
 
 *.anno.json
+
+tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,51 @@
 .PHONY: all download-surfer clean
+# Tywaves Surfer information
+TYWAVES_SURFER_NAME=surfer-tywaves-demo
+TYWAVES_SURFER_REPO=https://gitlab.com/rameloni/${TYWAVES_SURFER_NAME}.git
+TYWAVES_SURFER_VERSION=0.3.0
+TYWAVES_SURFER_TAG=v${TYWAVES_SURFER_VERSION}-tywaves-dev-SNAPSHOT
+TYWAVES_SURFER_BIN=surfer-tywaves
+TYWAVES_SURFER_TARGET_NAME=${TYWAVES_SURFER_BIN}-${TYWAVES_SURFER_VERSION}
+TYWAVES_SURFER_INSTALL_PATH=$(HOME)/.cargo/bin/
 
-TYWAVES_SURFER_REPO=https://gitlab.com/rameloni/surfer-tywaves-demo.git
-TYWAVES_BRANCH=v0.2.1-tywaves-dev-SNAPSHOT
-TYWAVES_NAME=surfer-tywaves-demo
-
+# Chisel information
 CHISEL_FORK_REPO=https://github.com/rameloni/chisel.git
-CHISEL_FORK_BRANCH=v6.1.0-tywaves-SNAPSHOT
+CHISEL_FORK_TAG=v6.4.1-tywaves-SNAPSHOT
 
-all: install-surfer-tywaves install-chisel-fork clean install-tywaves-backend
+# Circt (firtool) information
+CIRCT_FIRTOOL_ZIP_NAME=firtool-bin-linux-x64.tar.gz
+CIRCT_FORK_VERSION=0.1.1
+CIRCT_FORK_TAG=v${CIRCT_FORK_VERSION}-tywaves-SNAPSHOT
+CIRCT_FORK_FIRTOOL_ZIP_LINK=https://github.com/rameloni/circt/releases/download/${CIRCT_FORK_TAG}/${CIRCT_FIRTOOL_ZIP_NAME}
+CIRCT_FIRTOOL_NAME=firtool-type-dbg-info-${CIRCT_FORK_VERSION}
+CIRCT_FIRTOOL_INSTALL_PATH=$(HOME)/.local/bin/
+
+all: install-surfer-tywaves install-chisel-fork install-firtool-fork-bin clean install-tywaves-backend
 
 create-tmp:
 	@mkdir -p tmp/
 
 install-surfer-tywaves: create-tmp
-	@cd tmp/ && git clone -b $(TYWAVES_BRANCH) $(TYWAVES_SURFER_REPO) && cd $(TYWAVES_NAME) && git submodule update --init --recursive
-	@cd tmp/$(TYWAVES_NAME) && cargo install --path .
+	@cd tmp/ && git clone -b $(TYWAVES_SURFER_TAG) $(TYWAVES_SURFER_REPO) && cd $(TYWAVES_SURFER_NAME) && git submodule update --init --recursive
+	@#cd tmp/$(TYWAVES_SURFER_NAME) && cargo install --path .
+	@cd tmp/$(TYWAVES_SURFER_NAME) && cargo build --release
+	@cp tmp/$(TYWAVES_SURFER_NAME)/target/release/$(TYWAVES_SURFER_BIN) $(TYWAVES_SURFER_INSTALL_PATH)$(TYWAVES_SURFER_TARGET_NAME)
+	echo "installed $(TYWAVES_SURFER_TARGET_NAME) in $(TYWAVES_SURFER_INSTALL_PATH)"
 
 clean:
-	@rm -rf tmp/
+	$(RM) -rf tmp/
 
 install-chisel-fork: create-tmp
-	@cd tmp/ && git clone $(CHISEL_FORK_REPO) && cd chisel && git checkout $(CHISEL_FORK_BRANCH)
+	@cd tmp/ && git clone $(CHISEL_FORK_REPO) && cd chisel && git checkout $(CHISEL_FORK_TAG)
 	@cd tmp/chisel && sbt "unipublish / publishLocal"
 
 install-tywaves-backend:
 	@sbt publishLocal
+
+clean-firtool-fork-bin:
+	$(RM) tmp/$(CIRCT_FIRTOOL_ZIP_NAME)*
+
+install-firtool-fork-bin: clean-firtool-fork-bin create-tmp
+	# Extract the firtool binary from the forked circt repository
+	@cd tmp/ && wget $(CIRCT_FORK_FIRTOOL_ZIP_LINK) && tar -xf $(CIRCT_FIRTOOL_ZIP_NAME)
+	@cp tmp/bin/$(CIRCT_FIRTOOL_NAME) $(CIRCT_FIRTOOL_INSTALL_PATH)

--- a/build.sbt
+++ b/build.sbt
@@ -1,19 +1,34 @@
-val chiselVersion    = "6.1.0-tywaves-SNAPSHOT" // Local version of chisel
+val chiselVersion    = "6.4.1-tywaves-SNAPSHOT" // Local version of chisel
 val scalatestVersion = "3.2.16"
 val circeVersion     = "0.14.6"
+
+val firtoolVersion  = "0.1.1"
+val firtoolFullName = "firtool-type-dbg-info-" ++ firtoolVersion
+
+val surferTywavesVersion  = "0.3.0"
+val surferTywavesFullName = "surfer-tywaves-" ++ surferTywavesVersion
 
 Compile / scalaSource := baseDirectory.value / "src/main/scala"
 
 Test / scalaSource := baseDirectory.value / "src/test/scala"
 
 ThisBuild / organization := "com.github.rameloni"
-ThisBuild / version      := "0.2.1-SNAPSHOT"
+ThisBuild / version      := "0.3.0-SNAPSHOT"
 ThisBuild / scalaVersion := "2.13.12"
 
 enablePlugins(ScalafmtPlugin)
 
 lazy val root = (project in file("."))
+  .enablePlugins(BuildInfoPlugin)
   .settings(
+    buildInfoKeys := {
+      val firtoolBinaryPath       = BuildInfoKey("firtoolBinaryPath", firtoolFullName)
+      val surferTywavesBinaryPath = BuildInfoKey("surferTywavesBinaryPath", surferTywavesFullName)
+      Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, firtoolBinaryPath, surferTywavesBinaryPath)
+    },
+    buildInfoPackage          := "tywaves",
+    buildInfoUsePackageAsPath := true,
+  ).settings(
     name := "TyWaves-demo-backend",
     addCompilerPlugin(
       "org.chipsalliance" % "chisel-plugin" % chiselVersion cross CrossVersion.full
@@ -24,12 +39,10 @@ lazy val root = (project in file("."))
     libraryDependencies += "io.circe"          %% "circe-generic"        % circeVersion,
     libraryDependencies += "io.circe"          %% "circe-generic-extras" % "0.14.3",
     libraryDependencies += "io.circe"          %% "circe-parser"         % circeVersion,
-
     libraryDependencies ++= Seq(
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-      "ch.qos.logback" % "logback-classic" % "1.4.14"
+      "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.5",
+      "ch.qos.logback"              % "logback-classic" % "1.4.14",
     ),
-
     scalacOptions ++= Seq(
       "-deprecation",
       "-encoding",

--- a/example/gcd.test.scala
+++ b/example/gcd.test.scala
@@ -1,5 +1,5 @@
 //> using scala "2.13.12"
-//> using dep "com.github.rameloni::tywaves-demo-backend:0.2.1-SNAPSHOT"
+//> using dep "com.github.rameloni::tywaves-demo-backend:0.3.0-SNAPSHOT"
 //> using dep "org.chipsalliance::chisel:6.3.0"
 //> using plugin "org.chipsalliance:::chisel-plugin:6.3.0"
 //> using options "-unchecked", "-deprecation", "-language:reflectiveCalls", "-feature", "-Xcheckinit", "-Xfatal-warnings", "-Ywarn-dead-code", "-Ywarn-unused", "-Ymacro-annotations"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")

--- a/src/main/scala/chisel3/tywaves/circuitparser/ChiselIRParser.scala
+++ b/src/main/scala/chisel3/tywaves/circuitparser/ChiselIRParser.scala
@@ -7,6 +7,7 @@ import com.typesafe.scalalogging.Logger
 import tywaves.utils.UniqueHashMap
 import tywaves.circuitmapper.{Direction, ElId, HardwareType, Name, Type, tywaves_symbol_table}
 
+@deprecated("This class is not used anymore. It is kept for reference.", "0.3.0")
 class ChiselIRParser
     extends CircuitParser[chiselIR.Circuit, chiselIR.Component, chiselIR.Port, Aggregate, Data, chiselIR.Command] {
 

--- a/src/main/scala/chisel3/tywaves/circuitparser/CircuitParser.scala
+++ b/src/main/scala/chisel3/tywaves/circuitparser/CircuitParser.scala
@@ -3,6 +3,7 @@ package chisel3.tywaves.circuitparser
 import tywaves.circuitmapper.{Direction, ElId, HardwareType, Name, Type}
 import tywaves.utils.UniqueHashMap
 
+@deprecated("This trait is not used anymore. It is kept for reference.", "0.3.0")
 trait CircuitParser[T, ModuleT, PortT, AggregateT, ElementT, BodyStatementT] {
 
   lazy val modules        = new UniqueHashMap[ElId, (Name, ModuleT)]()
@@ -10,10 +11,14 @@ trait CircuitParser[T, ModuleT, PortT, AggregateT, ElementT, BodyStatementT] {
   lazy val flattenedPorts = new UniqueHashMap[ElId, (Name, Direction, HardwareType, Type)]()
   lazy val allElements    = new UniqueHashMap[ElId, (Name, Direction, Type)]()
 
+  @deprecated(since = "0.3.0")
   def parseCircuit(circuit: T): Unit
-  def parseModule(module:   ModuleT): Unit
-  def parsePort(scope:      String, port: PortT, parentModule: String): Unit
+  @deprecated(since = "0.3.0")
+  def parseModule(module: ModuleT): Unit
+  @deprecated(since = "0.3.0")
+  def parsePort(scope: String, port: PortT, parentModule: String): Unit
 
+  @deprecated(since = "0.3.0")
   def getWidth(agg: AggregateT): Int = {
     val widthPattern = "<(\\d+)>".r
     agg match {
@@ -39,6 +44,7 @@ trait CircuitParser[T, ModuleT, PortT, AggregateT, ElementT, BodyStatementT] {
     }
   }
 
+  @deprecated(since = "0.3.0")
   def parseAggregate(
       elId:         ElId,
       name:         Name,
@@ -62,6 +68,7 @@ trait CircuitParser[T, ModuleT, PortT, AggregateT, ElementT, BodyStatementT] {
     allElements.put(elId.addName(name.name + parentModule), (name.addTywaveScope(parentModule), dir, Type(aggString)))
   }
 
+  @deprecated(since = "0.3.0")
   def parseElement(
       elId:         ElId,
       name:         Name,
@@ -70,14 +77,17 @@ trait CircuitParser[T, ModuleT, PortT, AggregateT, ElementT, BodyStatementT] {
       element:      ElementT,
       parentModule: String,
   ): Unit
+  @deprecated(since = "0.3.0")
   def parseBodyStatement(scope: String, body: BodyStatementT, parentModule: String): Unit
 
+  @deprecated(since = "0.3.0")
   def dumpMaps(fileDump: String): Unit = {
     modules.dumpFile(fileDump, "Modules:", append = false)
     ports.dumpFile(fileDump, "Ports:")
     flattenedPorts.dumpFile(fileDump, "Flattened Ports:")
     allElements.dumpFile(fileDump, "Internal Elements:")
   }
+  @deprecated(since = "0.3.0")
   def dumpMaps(): Unit = {
     println()
     // Change color

--- a/src/main/scala/chisel3/tywaves/circuitparser/FirrtlIRParser.scala
+++ b/src/main/scala/chisel3/tywaves/circuitparser/FirrtlIRParser.scala
@@ -5,6 +5,7 @@ import firrtl.{ir => firrtlIR}
 import tywaves.utils.UniqueHashMap
 import tywaves.circuitmapper.{Direction, ElId, HardwareType, Name, Type}
 
+@deprecated("This class is not used anymore. It is kept for reference.", "0.3.0")
 class FirrtlIRParser
     extends CircuitParser[
       firrtlIR.Circuit,

--- a/src/main/scala/tywaves/circuitmapper/MapChiselToVcd.scala
+++ b/src/main/scala/tywaves/circuitmapper/MapChiselToVcd.scala
@@ -17,6 +17,7 @@ import scala.annotation.unused
  * It is used to extract the Chisel IR and the Firrtl IR from the ChiselStage
  * and then use it to generate the VCD file.
  */
+@deprecated(since = "0.3.0")
 class MapChiselToVcd[T <: RawModule](generateModule: () => T, private val workingDir: String = "workingDir")(
     topName:     String,
     tbScopeName: String,

--- a/src/main/scala/tywaves/circuitmapper/SymbolTable.scala
+++ b/src/main/scala/tywaves/circuitmapper/SymbolTable.scala
@@ -6,6 +6,7 @@ import scala.math.Ordered.orderingToOrdered
 
 // TODO: Define a case class to output the information in json with circe
 
+@deprecated(since = "0.3.0")
 object Defaults {
   lazy val elId   = ElId("", 0, 0)
   lazy val name   = Name("", "", "")
@@ -14,10 +15,13 @@ object Defaults {
   lazy val typ    = Type("")
 }
 
+@deprecated(since = "0.3.0")
 sealed trait CircuitIR
 
+@deprecated(since = "0.3.0")
 sealed trait CircuitIRElement
 
+@deprecated(since = "0.3.0")
 // TODO: Redefine the ElId in a more meaningful way
 case class ElId(
     source: String,
@@ -38,30 +42,37 @@ case class ElId(
   override def toString: String = s"$name:\t$row:\t$col:\t$source"
 }
 
+@deprecated(since = "0.3.0")
 case class Name(name: String, scope: String, tywaveScope: String) extends Ordered[Name] {
   def addTywaveScope(parentModule: String): Name = this.copy(tywaveScope = parentModule)
   override def compare(that: Name): Int =
     (this.name, this.scope, this.tywaveScope) compare ((that.name, that.scope, that.tywaveScope))
   override def toString: String = s"Name: $name, scope: $scope, tywaveScope: $tywaveScope"
 }
+@deprecated(since = "0.3.0")
 case class Type(name: String) extends Ordered[Type] {
   override def compare(that: Type): Int = this.name compare that.name
   override def toString: String = s"Type: $name"
 
 } // TODO: add pretty name to type
+@deprecated(since = "0.3.0")
 case class HardwareType(name: String, size: Option[Int]) {
   override def toString: String = s"HardwareType: $name"
 
 }
+@deprecated(since = "0.3.0")
 case class Direction(name: String) extends Ordered[Direction] {
   override def compare(that: Direction): Int = this.name compare that.name
   override def toString: String = s"Direction: $name"
 }
 
+@deprecated(since = "0.3.0")
 case class VerilogSignals(names: Seq[String])
 
+@deprecated(since = "0.3.0")
 object tywaves_symbol_table {
   import io.circe._
+  @deprecated(since = "0.3.0")
   object tywaves_encoders {
     import io.circe.generic.extras._
     implicit val customConfiguration: Configuration =
@@ -105,11 +116,14 @@ object tywaves_symbol_table {
   }
 
   /** The state for Tywaves */
+  @deprecated(since = "0.3.0")
   case class TywaveState(var scopes: Seq[Scope])
 
   /** A scope in the state */
+  @deprecated(since = "0.3.0")
   case class Scope(name: String, childVariables: Seq[Variable], childScopes: Seq[Scope])
 
+  @deprecated(since = "0.3.0")
   case class Variable(
       name:     String,
       typeName: String,
@@ -120,6 +134,7 @@ object tywaves_symbol_table {
   }
 
   /** Hardware types */
+  @deprecated(since = "0.3.0")
   object hwtype {
     def from_string(tpe: String, dir: Option[String]): HwType =
       (tpe, dir) match {
@@ -129,18 +144,25 @@ object tywaves_symbol_table {
       }
     sealed trait HwType
 
+    @deprecated(since = "0.3.0")
     case object Wire extends HwType
 
+    @deprecated(since = "0.3.0")
     case object Reg extends HwType
 
+    @deprecated(since = "0.3.0")
     case class Port(dir: direction.Directions) extends HwType
 
+    @deprecated(since = "0.3.0")
     case object Mem extends HwType
 
+    @deprecated(since = "0.3.0")
     case object Unknown extends HwType
   }
 
+  @deprecated(since = "0.3.0")
   object direction {
+    @deprecated(since = "0.3.0")
     def from_string(dir: String): Directions =
       dir match {
         case "Input"  => Input
@@ -149,14 +171,20 @@ object tywaves_symbol_table {
         case _        => Unknown
       }
 
+    @deprecated(since = "0.3.0")
     sealed trait Directions
 
-    case object Input   extends Directions
-    case object Output  extends Directions
-    case object Inout   extends Directions
+    @deprecated(since = "0.3.0")
+    case object Input extends Directions
+    @deprecated(since = "0.3.0")
+    case object Output extends Directions
+    @deprecated(since = "0.3.0")
+    case object Inout extends Directions
+    @deprecated(since = "0.3.0")
     case object Unknown extends Directions
   }
 
+  @deprecated(since = "0.3.0")
   object realtype {
 //    def from_string(tpe: String): RealType = {
 //      tpe match {
@@ -164,20 +192,25 @@ object tywaves_symbol_table {
 //        case
 //      }
 //    }
+    @deprecated(since = "0.3.0")
     sealed trait RealType {
       def getWidth: Int = 0
     }
+    @deprecated(since = "0.3.0")
     case class Ground(width: Int, vcdName: String) extends RealType {
       override def getWidth: Int = width
     }
+    @deprecated(since = "0.3.0")
     case class Vec(size: Int, fields: Seq[Variable]) extends RealType {
       override def getWidth: Int = if (fields.nonEmpty)
         size * fields.head.realType.getWidth
       else 0
     }
+    @deprecated(since = "0.3.0")
     case class Bundle(fields: Seq[Variable], vcdName: Option[String]) extends RealType {
       override def getWidth: Int = fields.map(f => f.getWidth).sum
     }
+    @deprecated(since = "0.3.0")
     case object Unknown extends RealType
   }
 

--- a/src/main/scala/tywaves/circuitmapper/TypedConverter.scala
+++ b/src/main/scala/tywaves/circuitmapper/TypedConverter.scala
@@ -3,18 +3,19 @@ package tywaves.circuitmapper
 import chisel3.RawModule
 import chisel3.stage.ChiselGeneratorAnnotation
 import firrtl.AnnotationSeq
+import tywaves.BuildInfo.firtoolBinaryPath
 
 import java.io.{BufferedReader, FileReader}
 
 /** This object exposes the Convert phase used in ChiselStage */
-private object TypedConverter {
+private[tywaves] object TypedConverter {
   private lazy val converter   = new chisel3.stage.phases.Convert
-  private lazy val chiselStage = new circt.stage.ChiselStage
+  private lazy val chiselStage = new circt.stage.ChiselStage(withDebug = true)
 
-  private val args = Array("--target", "systemverilog", "--split-verilog")
+  private val args = Array("--target", "systemverilog", "--split-verilog", "--firtool-binary-path", firtoolBinaryPath)
 
   private var hglddDebugDir   = "hgldd/debug"
-  private var hglddWithOptDir = "hgldd/opt"
+  private var hglddWithOptDir = "hgldd/opt" // TODO: remove
 
   // In the default annotations, emit also the debug hgldd file (a json file containing info from the debug dialect)
   private val defaultAnnotations =
@@ -32,6 +33,7 @@ private object TypedConverter {
   private def createFirtoolOptions(args: Seq[String]): AnnotationSeq =
     args.map(circt.stage.FirtoolOption).toSeq
 
+  @deprecated(since = "0.3.0")
   /** This function is used to add the FirrtlIR representation */
   def addFirrtlAnno(annotations: AnnotationSeq): AnnotationSeq =
     converter.transform(annotations)
@@ -55,6 +57,11 @@ private object TypedConverter {
     )
   }
 
+  def getDebugIRDir(gOpt: Boolean): String =
+    if (gOpt) hglddDebugDir
+    else hglddWithOptDir
+
+  @deprecated("This function is not used anymore. It is kept for reference.", "0.3.0")
   /** Get the name of the debug file */
   def getDebugIRFile(gOpt: Boolean, topModuleName: String): String = {
 

--- a/src/main/scala/tywaves/hglddparser/package.scala
+++ b/src/main/scala/tywaves/hglddparser/package.scala
@@ -6,6 +6,7 @@ package tywaves
  */
 package object hglddparser {
 
+  @deprecated(since = "0.3.0")
   /** Top component of the `hgldd.dd` file. */
   case class HglddTopInterface(HGLDD: HglddHeader, objects: Seq[HglddObject])
 
@@ -20,6 +21,7 @@ package object hglddparser {
    * @param hdl_file_index
    *   The index of the hdl file in the [[file_info]] list
    */
+  @deprecated(since = "0.3.0")
   case class HglddHeader(version: String, file_info: Seq[String], hdl_file_index: Int)
 
   /**
@@ -38,6 +40,7 @@ package object hglddparser {
    *   Optional param which would contain the names of the children modules of
    *   the object
    */
+  @deprecated(since = "0.3.0")
   case class HglddObject(
       hgl_loc:     HglLocation,
       kind:        String,
@@ -48,6 +51,7 @@ package object hglddparser {
       children:    Option[Seq[Child]],
   )
 
+  @deprecated(since = "0.3.0")
   case class HglLocation(
       begin_column: Int,
       begin_line:   Int,
@@ -55,6 +59,7 @@ package object hglddparser {
       end_line:     Int,
       file:         Int,// The index of the file in the file_info list
   )
+  @deprecated(since = "0.3.0")
   case class HdlLocation(begin_line: Int, end_line: Int, file: Int) // Imp: I can parse only the fields I need
 
   /**
@@ -65,6 +70,7 @@ package object hglddparser {
    * @param type_name
    *   the type in the HDL
    */
+  @deprecated(since = "0.3.0")
   case class PortVar(
       var_name:       String,
       hgl_loc:        HglLocation,
@@ -86,6 +92,7 @@ package object hglddparser {
    *   this is contains values of nested fields for aggregates like bundles and
    *   vecs. So it is possible to rebuild the hierarchy
    */
+  @deprecated(since = "0.3.0")
   case class Value(
       bit_vector: Option[String],
       sig_name:   Option[String],
@@ -93,6 +100,7 @@ package object hglddparser {
       operands:   Option[Seq[Value]],
   )
 
+  @deprecated(since = "0.3.0")
   case class Child(name: String, obj_name: String, module_name: String, hgl_loc: HglLocation, hdl_loc: HdlLocation)
 
 }

--- a/src/main/scala/tywaves/simulator/TywavesInterface.scala
+++ b/src/main/scala/tywaves/simulator/TywavesInterface.scala
@@ -2,9 +2,14 @@ package tywaves.simulator
 
 private[tywaves] object TywavesInterface {
 
-  private val program = "surfer-tywaves"
+  private val program = tywaves.BuildInfo.surferTywavesBinaryPath
 
-  def run(vcdPath: String, chiselState: Option[String]): Unit = {
+  def run(
+      vcdPath:       String,
+      hglddDirPath:  Option[String],
+      extraScopes:   Seq[String],
+      topModuleName: Option[String],
+  ): Unit = {
     {
       import scala.sys.process._
 
@@ -14,11 +19,18 @@ private[tywaves] object TywavesInterface {
         throw new Exception(s"$program not found on the PATH! Please install it running: make all\n")
     }
 
-    val chiselStateCmd = chiselState match {
-      case Some(_) => Some("--chisel-state")
+    val hglddDirCmd = hglddDirPath match {
+      case Some(_) => Some("--hgldd-dir")
       case None    => None
     }
-    val cmd = Seq(program, vcdPath) ++ chiselStateCmd ++ chiselState
+
+    val extraScopesCmd = (extraScopes, topModuleName) match {
+      case (Nil, _) | (_, None) => Nil
+      case _ => Seq("--extra-scopes") ++ extraScopes ++
+          Seq("--top-module") ++ topModuleName
+    }
+
+    val cmd = Seq(program, vcdPath) ++ hglddDirCmd ++ hglddDirPath ++ extraScopesCmd
 
     // Execute and return to the caller
     val process = new ProcessBuilder(cmd: _*).inheritIO().start()


### PR DESCRIPTION
- Replace the old (buggy) pipeline with the new tywaves pipeline to generate the debug information and load the surfer viewer
- Update the interface and versions in Makefile of:
	- chisel fork
	- circt fork
	- surfer
- Mark old IRs as deprecated (they will be removed with a future commit)